### PR TITLE
Refactor codec into separate crate, relicense it as MIT/Apache 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,18 +3538,26 @@ version = "0.2.0"
 dependencies = [
  "ahrs",
  "async-std",
- "deku",
  "directories",
  "iced",
  "iced_native",
  "itertools",
  "joycon",
  "joycon-rs",
- "md-5",
  "nalgebra",
  "self_update",
  "serde",
  "serde_json",
+ "slimevr_codec",
+]
+
+[[package]]
+name = "slimevr_codec"
+version = "0.0.1"
+dependencies = [
+ "deku",
+ "md-5",
+ "nalgebra",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
+[workspace]
+members = ["codec"]
+
 [package]
 name = "slimevr-wrangler"
 version = "0.2.0"
 edition = "2021"
+license = "GPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,8 +22,7 @@ self_update = { version = "0.27", features = ["archive-zip", "compression-zip-de
 itertools = "0.10"
 ahrs = "0.4"
 nalgebra = "0.21"
-deku = "0.12"
-md-5 = "0.9"
+slimevr_codec = { path = "codec" }
 
 [features]
 default = ["use-joycon-rs"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use joy-Con's (+) as SlimeVR trackers, enabling you to make a full body system w
 You need bluetooth on your computer.
 * Download and set up [SlimeVR](https://docs.slimevr.dev/slimevr-setup.html)
 * Download [SlimeVR Wrangler](https://github.com/carl-anders/slimevr-wrangler/releases/latest/download/slimevr-wrangler.exe)
-* Start both the SlimeVR server and SlimeVR Wrangler 
+* Start both the SlimeVR server and SlimeVR Wrangler
 * Connect your Joy-Con trackers to the computer ([Guide for Windows](https://www.digitaltrends.com/gaming/how-to-connect-a-nintendo-switch-controller-to-a-pc/))
 * Make sure the SlimeVR server is running, then press "Search for Joycons" inside SlimeVR Wrangler
 * The Joy-Con should show up in the window!
@@ -45,6 +45,6 @@ This is a problem that might be related to a newer Windows update. Try this, and
 * Pair the device again. It should now show up.
 
 # License
-GPLv3
+The application code is licensed under GPLv3 due to a GPL dependency. The `slimevr_codec` crate is dually licensed under MIT and Apache 2.0, *not* GPLv3.
 
-If you contribute to this, you also agree to license your contributions with MIT License & Apache License, Version 2.0. This is because I might replace the GPL dependency in the future with something else.
+If you contribute to this repository, you also agree to license your contributions with MIT License & Apache License, Version 2.0. This is because I might eventually make the application code MIT/Apache 2.0 licensed in the future.

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "slimevr_codec"
+version = "0.0.1"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[features]
+default = ["nalgebra"]
+
+[dependencies]
+deku = "0.12"
+nalgebra = { version = "0.21", optional = true }
+
+[dev-dependencies]
+md-5 = "0.9"

--- a/codec/LICENSE-APACHE
+++ b/codec/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2022 Ryan Butler
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/codec/LICENSE-MIT
+++ b/codec/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Ryan Butler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/codec/README.md
+++ b/codec/README.md
@@ -1,0 +1,5 @@
+# SlimeVR Codec
+This crate provides a codec to encode and decode communications with the SlimeVR server.
+
+## License
+This crate is dually licensed under the MIT and Apache 2.0 licenses.

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -1,6 +1,10 @@
+pub use deku; // re-export dependency used in public API
+
 use std::string::FromUtf8Error;
 
 use deku::prelude::*;
+
+#[cfg(feature = "nalgebra")]
 use nalgebra::Quaternion;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -11,6 +15,7 @@ pub struct SlimeQuaternion {
     pub k: f32,
     pub w: f32,
 }
+#[cfg(feature = "nalgebra")]
 impl From<Quaternion<f64>> for SlimeQuaternion {
     fn from(q: Quaternion<f64>) -> Self {
         Self {
@@ -21,6 +26,7 @@ impl From<Quaternion<f64>> for SlimeQuaternion {
         }
     }
 }
+#[cfg(feature = "nalgebra")]
 impl From<SlimeQuaternion> for Quaternion<f64> {
     fn from(q: SlimeQuaternion) -> Self {
         Self::new(q.w as _, q.i as _, q.j as _, q.k as _)
@@ -72,9 +78,7 @@ pub enum PacketType {
         mac_address: [u8; 6],
     },
     #[deku(id = "10")]
-    Ping {
-        id: u32,
-    },
+    Ping { id: u32 },
     #[deku(id = "15")]
     SensorInfo {
         packet_id: u64,

--- a/codec/tests/test_deku.rs
+++ b/codec/tests/test_deku.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::slime::deku::PacketType;
-    use deku::{DekuContainerWrite, DekuContainerRead};
     use md5::{Digest, Md5};
     use nalgebra::{Quaternion, UnitQuaternion};
+    use slimevr_codec::deku::{DekuContainerRead, DekuContainerWrite};
+    use slimevr_codec::PacketType;
 
     #[test]
     fn handshake() {

--- a/src/joycon/communication.rs
+++ b/src/joycon/communication.rs
@@ -6,9 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use deku::{DekuContainerRead, DekuContainerWrite};
-
-use crate::slime::deku::PacketType;
+use slimevr_codec::deku::{DekuContainerRead, DekuContainerWrite};
+use slimevr_codec::PacketType;
 
 use super::{
     imu::{Imu, JoyconAxisData},

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use std::{
 mod joycon;
 use crate::joycon::{JoyconIntegration, JoyconStatus, JoyconSvg};
 mod settings;
-mod slime;
 mod style;
 mod update;
 use settings::WranglerSettings;

--- a/src/slime/mod.rs
+++ b/src/slime/mod.rs
@@ -1,2 +1,0 @@
-pub mod deku;
-mod test_deku;


### PR DESCRIPTION
To better enable other applications to use Rust with SlimeVR, it would be awesome to create a codec crate that enables serialization/deserialization to/from the SlimeVR server and the SlimeVR firmware.

I have refactored the deku stuff into a new `slimevr_codec` crate. I also took the liberty of licensing it as MIT/Apache 2.0, since it does not have the dependency on AHRS.

This way, if someone wants to write SlimeVR firmware in rust, or add rust support to some other device, they can easily leverage the `slimevr_codec` crate to handle the serialization.