### PR TITLE
Allow for editing the gyro scale factor (editable in config file only)

### DIFF
--- a/src/joycon/integration_with_joy.rs
+++ b/src/joycon/integration_with_joy.rs
@@ -1,6 +1,7 @@
 use super::communication::{ChannelInfo, JoyconData, JoyconDeviceInfo};
 use super::imu::JoyconAxisData;
 use super::{JoyconDesign, JoyconDesignType};
+use crate::settings;
 use joycon::joycon_sys::spi::ControllerColor;
 use joycon::{
     hidapi::HidApi,
@@ -56,7 +57,7 @@ fn joycon_thread(sn: String, mut joycon: JoyCon, tx: mpsc::Sender<ChannelInfo>) 
     }
 }
 
-pub fn spawn_thread(tx: mpsc::Sender<ChannelInfo>) {
+pub fn spawn_thread(tx: mpsc::Sender<ChannelInfo>, settings: settings::Handler) {
     let mut api = HidApi::new().unwrap();
     let mut connected_controllers: HashSet<String> = HashSet::new();
     loop {

--- a/src/joycon/wrapper.rs
+++ b/src/joycon/wrapper.rs
@@ -7,8 +7,9 @@ use super::{main_thread, spawn_thread, JoyconStatus};
 fn startup(settings: settings::Handler) -> mpsc::Receiver<Vec<JoyconStatus>> {
     let (out_tx, out_rx) = mpsc::channel();
     let (tx, rx) = mpsc::channel();
+    let settings_clone = settings.clone();
     let _drop = std::thread::spawn(move || main_thread(rx, out_tx, settings));
-    std::thread::spawn(move || spawn_thread(tx));
+    std::thread::spawn(move || spawn_thread(tx, settings_clone));
     out_rx
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,10 +7,21 @@ use serde::{Deserialize, Serialize};
 fn file_name() -> Option<PathBuf> {
     ProjectDirs::from("", "", "SlimeVR Wrangler").map(|pd| pd.config_dir().join("config.json"))
 }
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Joycon {
     pub rotation: i32,
+    pub gyro_scale_factor: f64, //[f64; 3],
 }
+
+impl Default for Joycon {
+    fn default() -> Self {
+        Joycon {
+            rotation: 0,
+            gyro_scale_factor: 1.0, //[1.0; 3]
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct WranglerSettings {
     pub address: String,


### PR DESCRIPTION
Currently this does not have a UI, and it would probably be better if there was at least an option to adjust the factor for each axis individually, given a more advanced calibration setup.

A value of 360/348 (approx. 1.0344) gets my joycons to roughly a usable state. This may vary for other people. The value comes from the fact that when i performed a 360 degree rotation, it would only rotate 348 degrees.