### PR TITLE
Refactor deku protocol into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
 
 [[package]]
+name = "protocol"
+version = "0.0.0"
+dependencies = [
+ "deku",
+ "nalgebra",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3475,6 @@ version = "0.7.1"
 dependencies = [
  "arc-swap",
  "async-std",
- "deku",
  "directories",
  "iced",
  "iced_native",
@@ -3475,6 +3482,7 @@ dependencies = [
  "joycon-rs",
  "keyvalues-parser",
  "nalgebra",
+ "protocol",
  "regex",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["protocol"]
+resolver = "2"
+
 [package]
 name = "slimevr-wrangler"
 version = "0.7.1"
@@ -14,10 +18,13 @@ iced_native = "0.7"
 async-std = "1.0"
 joycon-rs = { git = "https://github.com/carl-anders/joycon-rs" }
 directories = "4.0"
-self_update = { version = "0.32", features = ["archive-zip", "compression-zip-deflate"] }
+self_update = { version = "0.32", features = [
+	"archive-zip",
+	"compression-zip-deflate",
+] }
+protocol = { path = "protocol" }
 itertools = "0.10"
 nalgebra = "0.30"
-deku = "0.15"
 arc-swap = "1.5"
 vqf-cxx = { git = "https://github.com/carl-anders/vqf-cxx" }
 keyvalues-parser = "0.1.0"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "protocol"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+deku = "0.15"
+nalgebra = "0.30"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,3 +1,7 @@
+mod test_deku;
+
+pub use deku;
+
 use std::string::FromUtf8Error;
 
 use deku::prelude::*;

--- a/protocol/src/test_deku.rs
+++ b/protocol/src/test_deku.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::slime::deku::PacketType;
     use deku::{DekuContainerRead, DekuContainerWrite};
     use nalgebra::{Quaternion, UnitQuaternion};
+
+    use crate::PacketType;
 
     #[test]
     fn handshake() {
@@ -85,7 +86,10 @@ mod tests {
             sensor_id: Some(32),
         };
 
-        let data: Vec<u8> = vec![0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 16, 61, 204, 204, 205, 63, 0, 0, 0, 63, 102, 102, 102, 32];
+        let data: Vec<u8> = vec![
+            0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 16, 61, 204, 204, 205, 63, 0, 0, 0, 63, 102, 102, 102,
+            32,
+        ];
 
         assert_eq!(acc.to_bytes().unwrap(), data);
     }

--- a/src/joycon/communication.rs
+++ b/src/joycon/communication.rs
@@ -6,16 +6,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use deku::{DekuContainerRead, DekuContainerWrite};
 use itertools::Itertools;
 use nalgebra::{UnitQuaternion, Vector3};
-
-use crate::{settings, slime::deku::PacketType};
+use protocol::deku::{DekuContainerRead, DekuContainerWrite};
+use protocol::PacketType;
 
 use super::{
     imu::{Imu, JoyconAxisData},
     JoyconDesign,
 };
+use crate::settings;
 
 #[derive(Debug, Clone)]
 pub struct JoyconStatus {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ mod steam_blacklist;
 use crate::joycon::{JoyconIntegration, JoyconStatus, JoyconSvg};
 use steam_blacklist as blacklist;
 mod settings;
-mod slime;
 mod style;
 mod update;
 

--- a/src/slime/mod.rs
+++ b/src/slime/mod.rs
@@ -1,2 +1,0 @@
-pub mod deku;
-mod test_deku;


### PR DESCRIPTION
I would like to use the protocol as part of the [rust firmware](https://github.com/SlimeVR/SlimeVR-Rust/tree/main/firmware) I'm writing for SlimeVR, so I broke it into a separate crate to facilitate that.