### PR TITLE
Make nalgebra optional in protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "nalgebra-macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,7 +2960,8 @@ name = "protocol"
 version = "0.0.0"
 dependencies = [
  "deku",
- "nalgebra",
+ "nalgebra 0.30.1",
+ "nalgebra 0.31.4",
 ]
 
 [[package]]
@@ -3481,7 +3498,7 @@ dependencies = [
  "itertools 0.10.5",
  "joycon-rs",
  "keyvalues-parser",
- "nalgebra",
+ "nalgebra 0.30.1",
  "protocol",
  "regex",
  "self_update",
@@ -4085,7 +4102,7 @@ dependencies = [
  "autocxx-build",
  "cxx",
  "miette",
- "nalgebra",
+ "nalgebra 0.30.1",
  "normpath",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
 
 [[package]]
+name = "protocol"
+version = "0.0.0"
+dependencies = [
+ "deku",
+ "nalgebra",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3475,6 @@ version = "0.7.1"
 dependencies = [
  "arc-swap",
  "async-std",
- "deku",
  "directories",
  "iced",
  "iced_native",
@@ -3475,6 +3482,7 @@ dependencies = [
  "joycon-rs",
  "keyvalues-parser",
  "nalgebra",
+ "protocol",
  "regex",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ self_update = { version = "0.32", features = [
 	"archive-zip",
 	"compression-zip-deflate",
 ] }
-protocol = { path = "protocol" }
+protocol = { path = "protocol", features = ["nalgebra030"] }
 itertools = "0.10"
 nalgebra = "0.30"
 arc-swap = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["protocol"]
+resolver = "2"
+
 [package]
 name = "slimevr-wrangler"
 version = "0.7.1"
@@ -14,10 +18,13 @@ iced_native = "0.7"
 async-std = "1.0"
 joycon-rs = { git = "https://github.com/carl-anders/joycon-rs" }
 directories = "4.0"
-self_update = { version = "0.32", features = ["archive-zip", "compression-zip-deflate"] }
+self_update = { version = "0.32", features = [
+	"archive-zip",
+	"compression-zip-deflate",
+] }
+protocol = { path = "protocol" }
 itertools = "0.10"
 nalgebra = "0.30"
-deku = "0.15"
 arc-swap = "1.5"
 vqf-cxx = { git = "https://github.com/carl-anders/vqf-cxx" }
 keyvalues-parser = "0.1.0"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 
 [dependencies]
 deku = "0.15"
-nalgebra = "0.30"
+# We support multiple versions of nalgebra since it changes so much.
+nalgebra031 = { package = "nalgebra", version = "0.31", optional = true }
+nalgebra030 = { package = "nalgebra", version = "0.30", optional = true }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "protocol"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+deku = "0.15"
+nalgebra = "0.30"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -5,7 +5,6 @@ pub use deku;
 use std::string::FromUtf8Error;
 
 use deku::prelude::*;
-use nalgebra::Quaternion;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
@@ -15,19 +14,46 @@ pub struct SlimeQuaternion {
     pub k: f32,
     pub w: f32,
 }
-impl From<Quaternion<f64>> for SlimeQuaternion {
-    fn from(q: Quaternion<f64>) -> Self {
-        Self {
-            i: q.i as _,
-            j: q.j as _,
-            k: q.k as _,
-            w: q.w as _,
+#[cfg(feature = "nalgebra031")]
+mod nalgebra031_impls {
+    use super::*;
+    use nalgebra031::Quaternion;
+
+    impl From<Quaternion<f64>> for SlimeQuaternion {
+        fn from(q: Quaternion<f64>) -> Self {
+            Self {
+                i: q.i as _,
+                j: q.j as _,
+                k: q.k as _,
+                w: q.w as _,
+            }
+        }
+    }
+    impl From<SlimeQuaternion> for Quaternion<f64> {
+        fn from(q: SlimeQuaternion) -> Self {
+            Self::new(q.w as _, q.i as _, q.j as _, q.k as _)
         }
     }
 }
-impl From<SlimeQuaternion> for Quaternion<f64> {
-    fn from(q: SlimeQuaternion) -> Self {
-        Self::new(q.w as _, q.i as _, q.j as _, q.k as _)
+#[cfg(feature = "nalgebra030")]
+mod nalgebra030_impls {
+    use super::*;
+    use nalgebra030::Quaternion;
+
+    impl From<Quaternion<f64>> for SlimeQuaternion {
+        fn from(q: Quaternion<f64>) -> Self {
+            Self {
+                i: q.i as _,
+                j: q.j as _,
+                k: q.k as _,
+                w: q.w as _,
+            }
+        }
+    }
+    impl From<SlimeQuaternion> for Quaternion<f64> {
+        fn from(q: SlimeQuaternion) -> Self {
+            Self::new(q.w as _, q.i as _, q.j as _, q.k as _)
+        }
     }
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,3 +1,7 @@
+mod test_deku;
+
+pub use deku;
+
 use std::string::FromUtf8Error;
 
 use deku::prelude::*;

--- a/protocol/src/test_deku.rs
+++ b/protocol/src/test_deku.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::slime::deku::PacketType;
     use deku::{DekuContainerRead, DekuContainerWrite};
     use nalgebra::{Quaternion, UnitQuaternion};
+
+    use crate::PacketType;
 
     #[test]
     fn handshake() {
@@ -85,7 +86,10 @@ mod tests {
             sensor_id: Some(32),
         };
 
-        let data: Vec<u8> = vec![0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 16, 61, 204, 204, 205, 63, 0, 0, 0, 63, 102, 102, 102, 32];
+        let data: Vec<u8> = vec![
+            0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 16, 61, 204, 204, 205, 63, 0, 0, 0, 63, 102, 102, 102,
+            32,
+        ];
 
         assert_eq!(acc.to_bytes().unwrap(), data);
     }

--- a/src/joycon/communication.rs
+++ b/src/joycon/communication.rs
@@ -6,16 +6,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use deku::{DekuContainerRead, DekuContainerWrite};
 use itertools::Itertools;
 use nalgebra::{UnitQuaternion, Vector3};
-
-use crate::{settings, slime::deku::PacketType};
+use protocol::deku::{DekuContainerRead, DekuContainerWrite};
+use protocol::PacketType;
 
 use super::{
     imu::{Imu, JoyconAxisData},
     JoyconDesign,
 };
+use crate::settings;
 
 #[derive(Debug, Clone)]
 pub struct JoyconStatus {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ mod steam_blacklist;
 use crate::joycon::{JoyconIntegration, JoyconStatus, JoyconSvg};
 use steam_blacklist as blacklist;
 mod settings;
-mod slime;
 mod style;
 mod update;
 

--- a/src/slime/mod.rs
+++ b/src/slime/mod.rs
@@ -1,2 +1,0 @@
-pub mod deku;
-mod test_deku;


### PR DESCRIPTION
Rebased on #21 
This will enable people to opt out of nalgebra, or use the protocol with newer nalgebra versions.