### PR TITLE
Add rustfmt.toml to describe format

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Follow rustfmt defaults


### PR DESCRIPTION
I wanted to modify it from the defaults to be:
```
max_width = 88  # follow python black and improve readability for side-by-side editing
hard_tabs = true # allow users to reconfigure indent width
```
but I didn't want to be *that* guy 😅 so I left it as what you already had.
 